### PR TITLE
Add unit tests & CI support

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,87 @@
+{
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "try",
+    "catch"
+  ],
+  "requireOperatorBeforeLineBreak": true,
+  "requireParenthesesAroundIIFE": true,
+  "requireCommaBeforeLineBreak": true,
+  "requireDotNotation": true,
+  "requireBlocksOnNewline": 1,
+  "maximumLineLength": {
+    "value": 100,
+    "tabSize": 4,
+    "allowUrlComments": true,
+    "allowRegex": true
+  },
+  "validateQuoteMarks": { "mark": "'", "escape": true },
+
+  "disallowMultipleVarDecl": true,
+  "disallowMixedSpacesAndTabs": "smart",
+  "disallowTrailingWhitespace": true,
+  "disallowMultipleLineStrings": true,
+  "disallowTrailingComma": true,
+  "validateIndentation": 2,
+
+  "requireSpacesInFunctionExpression": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInFunctionDeclaration": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInFunctionDeclaration": {
+    "beforeOpeningRoundBrace": true
+  },
+
+  "requireSpaceAfterKeywords": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "switch",
+    "return",
+    "try",
+    "catch"
+  ],
+  "requireSpaceBetweenArguments": true,
+  "requireSpacesInsideObjectBrackets": {
+    "allExcept": [ "}", ")" ]
+  },
+  "requireSpacesInsideArrayBrackets": {
+    "allExcept": [ "[", "{", "}", "]" ]
+  },
+  "requireSpacesInsideParentheses": {
+    "all": true,
+    "except": [ "{", "}", "[", "]", ")", "function" ]
+  },
+  "requireSpacesInConditionalExpression": true,
+  "requireSpaceAfterBinaryOperators": true,
+  "requireLineFeedAtFileEnd": true,
+  "requireSpaceAfterPrefixUnaryOperators": [ "!" ],
+  "requireSpaceBeforeBinaryOperators": [
+    "=", "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=",
+    "&=", "|=", "^=", "+=",
+
+    "+", "-", "*", "/", "%", "<<", ">>", ">>>", "&",
+    "|", "^", "&&", "||", "===", "==", ">=",
+    "<=", "<", ">", "!=", "!=="
+  ],
+  "validateLineBreaks": "LF",
+
+  "disallowKeywords": [ "with" ],
+  "disallowKeywordsOnNewLine": [ "else" ],
+  "disallowSpaceAfterObjectKeys": true,
+  "disallowSpaceAfterPrefixUnaryOperators": [ "++", "--", "+", "-", "~" ],
+  "disallowSpaceBeforePostfixUnaryOperators": true,
+  "disallowSpaceBeforeBinaryOperators": [ ",", ":" ],
+  "disallowMultipleLineBreaks": true
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,13 @@
+{
+  "boss": true,
+  "curly": true,
+  "eqeqeq": true,
+  "eqnull": true,
+  "expr": true,
+  "noarg": true,
+  "strict": true,
+  "undef": true,
+  "unused": "vars",
+
+  "node": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+script:
+  # npm test, with bonus --reporter=list parameter
+  - npm run ci
+node_js:
+  - "iojs"
+  - "0.12"
+  - "0.11"
+  - "0.10"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,78 @@
+var _ = require( 'lodash' );
+
+module.exports = function( grunt ) {
+  'use strict';
+
+  // Reusable file globbing
+  var files = {
+    grunt: [ 'Gruntfile.js' ],
+    lib: [
+      'api.js',
+      'lib/*.js'
+    ],
+    tests: [ 'tests/**/*.js' ]
+  };
+
+  // Reusable JSHintRC options
+  var jshintrc = grunt.file.readJSON( '.jshintrc' );
+
+  // Load tasks.
+  grunt.loadNpmTasks( 'grunt-contrib-jshint' );
+  grunt.loadNpmTasks( 'grunt-jscs' );
+
+  grunt.initConfig({
+
+    pkg: grunt.file.readJSON( 'package.json' ),
+
+    jscs: {
+      options: {
+        config: '.jscsrc',
+        reporter: require( 'jscs-stylish' ).path
+      },
+      grunt: {
+        src: files.grunt
+      },
+      lib: {
+        src: files.lib
+      },
+      tests: {
+        src: files.tests
+      }
+    },
+
+    jshint: {
+      options: {
+        reporter: require( 'jshint-stylish' )
+      },
+      grunt: {
+        options: jshintrc,
+        src: files.grunt
+      },
+      lib: {
+        options: jshintrc,
+        src: files.lib
+      },
+      tests: {
+        options: _.merge({
+          mocha: true
+        }, jshintrc ),
+        src: files.tests
+      }
+    },
+
+    watch: {
+      lib: {
+        files: files.lib,
+        tasks: [ 'jscs:lib', 'jshint:lib' ]
+      },
+      tests: {
+        files: files.tests,
+        tasks: [ 'jscs:tests', 'jshint:tests' ]
+      }
+    }
+
+  });
+
+  grunt.registerTask( 'lint', [ 'jshint', 'jscs' ] );
+  grunt.registerTask( 'default', [ 'lint' ] );
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A wrapper interface for requesting data from the MBTA Realtime API v2",
   "main": "api.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "ci": "npm test -- --reporter=list",
+    "lint": "grunt lint",
+    "test": "mocha ./tests/specs/*.js ./tests/specs/**/*.js --reporter=nyan",
+    "pretest": "npm run lint"
   },
   "repository": {
     "type": "git",
@@ -20,5 +23,19 @@
     "bluebird": "^2.9.27",
     "lodash": "^3.9.3",
     "restler": "^3.2.2"
+  },
+  "devDependencies": {
+    "chai": "^3.2.0",
+    "chai-as-promised": "^5.1.0",
+    "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
+    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-jscs": "^2.1.0",
+    "jscs-stylish": "^0.3.1",
+    "jshint-stylish": "^2.0.1",
+    "mocha": "^2.3.2",
+    "proxyquire": "^1.7.2",
+    "sinon": "^1.16.1",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A wrapper interface for requesting data from the MBTA Realtime API v2",
   "main": "api.js",
   "scripts": {
-    "ci": "npm test -- --reporter=list",
+    "ci": "npm run lint && mocha ./tests/specs/*.js ./tests/specs/**/*.js --reporter=list",
     "lint": "grunt lint",
     "test": "mocha ./tests/specs/*.js ./tests/specs/**/*.js --reporter=nyan",
     "pretest": "npm run lint"

--- a/tests/mocks/mock-restler.js
+++ b/tests/mocks/mock-restler.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var sinon = require( 'sinon' );
+
+// Permits infinite chaining to simulate restler API
+function basicOn() {
+  return {
+    on: basicOn
+  };
+}
+
+module.exports = {
+  make: function( fireOnEvent, data ) {
+    return {
+      get: sinon.stub().returns({
+        on: basicOn
+      })
+    };
+  }
+};

--- a/tests/specs/api.js
+++ b/tests/specs/api.js
@@ -1,0 +1,344 @@
+'use strict';
+
+/*jshint -W106 */// Disable underscore_case warnings in this file
+var chai = require( 'chai' );
+var expect = chai.expect;
+chai.use( require( 'sinon-chai' ) );
+chai.use( require( 'chai-as-promised' ) );
+var proxyquire = require( 'proxyquire' );
+
+var mockRestler = require( '../mocks/mock-restler' );
+
+describe( 'mbtapi', function() {
+
+  var restler;
+  var mbtapi;
+
+  beforeEach(function() {
+    // Default stub behavior: always succeed
+    restler = mockRestler.make( 'success' );
+
+    mbtapi = proxyquire( '../../api', {
+      // Mock out the deps for the module api-query uses to create endpoint handlers
+      './lib/make-query-handler': proxyquire( '../../lib/make-query-handler', {
+        'restler': restler
+      })
+    });
+
+  });
+
+  describe( '.create', function() {
+    it( 'exists', function() {
+      expect( mbtapi ).to.have.property( 'create' );
+    });
+
+    it( 'is a function', function() {
+      expect( mbtapi.create ).to.be.a( 'function' );
+    });
+
+    it( 'requires a config object with an apiKey', function() {
+      expect(function() {
+        mbtapi.create({});
+      }).to.throw;
+      expect(function() {
+        mbtapi.create({
+          apiKey: 'key'
+        });
+      }).not.to.throw;
+    });
+
+    it( 'returns an API client object', function() {
+      expect( mbtapi.create({
+        apiKey: 'key'
+      })).to.be.an( 'object' );
+    });
+  });
+
+  describe( 'client object', function() {
+    var mbtapiClient;
+
+    beforeEach(function() {
+      mbtapiClient = mbtapi.create({
+        apiRoot: 'apiroot/v2/',
+        apiKey: 'apikey'
+      });
+    });
+
+    describe( '.routes', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'routes' );
+        expect( mbtapiClient.routes ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the routes endpoint', function() {
+        mbtapiClient.routes();
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/routes?api_key=apikey&format=json' );
+      });
+
+    });
+
+    describe( '.routesByStop', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'routesByStop' );
+        expect( mbtapiClient.routesByStop ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the routesbystop endpoint', function() {
+        mbtapiClient.routesByStop( 'stopID' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/routesbystop?stop=stopID&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "stop" parameter to be specified', function() {
+        expect( mbtapiClient.routesByStop() ).to.be
+          .rejectedWith( 'missing required parameter: stop' );
+      });
+
+    });
+
+    describe( '.stopsByRoute', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'stopsByRoute' );
+        expect( mbtapiClient.stopsByRoute ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the stopsbyroute endpoint', function() {
+        mbtapiClient.stopsByRoute( 'routeID' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/stopsbyroute?route=routeID&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "route" parameter to be specified', function() {
+        expect( mbtapiClient.stopsByRoute() ).to.be
+          .rejectedWith( 'missing required parameter: route' );
+      });
+
+    });
+
+    describe( '.stopsByLocation', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'stopsByLocation' );
+        expect( mbtapiClient.stopsByLocation ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the stopsbylocation endpoint', function() {
+        mbtapiClient.stopsByLocation( 42, -71 );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/stopsbylocation?lat=42&lon=-71&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "lat" parameter to be specified', function() {
+        expect( mbtapiClient.stopsByLocation() ).to.be
+          .rejectedWith( 'missing required parameter: lat' );
+      });
+
+      it( 'requires the "lon" parameter to be specified', function() {
+        expect( mbtapiClient.stopsByLocation( 42.352913 ) ).to.be
+          .rejectedWith( 'missing required parameter: lon' );
+      });
+
+    });
+
+    describe( '.scheduleByStop', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'scheduleByStop' );
+        expect( mbtapiClient.scheduleByStop ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the schedulebystop endpoint', function() {
+        mbtapiClient.scheduleByStop( 'stopID' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/schedulebystop?stop=stopID&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "stop" parameter to be specified', function() {
+        expect( mbtapiClient.scheduleByStop() ).to.be
+          .rejectedWith( 'missing required parameter: stop' );
+      });
+
+    });
+
+    describe( '.scheduleByRoute', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'scheduleByRoute' );
+        expect( mbtapiClient.scheduleByRoute ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the schedulebyroute endpoint', function() {
+        mbtapiClient.scheduleByRoute( 'routeID' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/schedulebyroute?route=routeID&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "route" parameter to be specified', function() {
+        expect( mbtapiClient.scheduleByRoute() ).to.be
+          .rejectedWith( 'missing required parameter: route' );
+      });
+
+    });
+
+    describe( '.scheduleByTrip', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'scheduleByTrip' );
+        expect( mbtapiClient.scheduleByTrip ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the schedulebytrip endpoint', function() {
+        mbtapiClient.scheduleByTrip( 'tripId' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/schedulebytrip?trip=tripId&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "trip" parameter to be specified', function() {
+        expect( mbtapiClient.scheduleByTrip() ).to.be
+          .rejectedWith( 'missing required parameter: trip' );
+      });
+
+    });
+
+    describe( '.predictionsByStop', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'predictionsByStop' );
+        expect( mbtapiClient.predictionsByStop ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the predictionsbystop endpoint', function() {
+        mbtapiClient.predictionsByStop( 'stopID' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/predictionsbystop?stop=stopID&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "stop" parameter to be specified', function() {
+        expect( mbtapiClient.predictionsByStop() ).to.be
+          .rejectedWith( 'missing required parameter: stop' );
+      });
+
+    });
+
+    describe( '.predictionsByRoute', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'predictionsByRoute' );
+        expect( mbtapiClient.predictionsByRoute ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the predictionsbyroute endpoint', function() {
+        mbtapiClient.predictionsByRoute( 'routeID' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/predictionsbyroute?route=routeID&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "route" parameter to be specified', function() {
+        expect( mbtapiClient.predictionsByRoute() ).to.be
+          .rejectedWith( 'missing required parameter: route' );
+      });
+
+    });
+
+    describe( '.predictionsByTrip', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'predictionsByTrip' );
+        expect( mbtapiClient.predictionsByTrip ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the predictionsbytrip endpoint', function() {
+        mbtapiClient.predictionsByTrip( 'tripId' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/predictionsbytrip?trip=tripId&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "trip" parameter to be specified', function() {
+        expect( mbtapiClient.predictionsByTrip() ).to.be
+          .rejectedWith( 'missing required parameter: trip' );
+      });
+
+    });
+
+    describe( '.vehiclesByRoute', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'vehiclesByRoute' );
+        expect( mbtapiClient.vehiclesByRoute ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the vehiclesbyroute endpoint', function() {
+        mbtapiClient.vehiclesByRoute( 'routeID' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/vehiclesbyroute?route=routeID&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "route" parameter to be specified', function() {
+        expect( mbtapiClient.vehiclesByRoute() ).to.be
+          .rejectedWith( 'missing required parameter: route' );
+      });
+
+    });
+
+    describe( '.vehiclesByTrip', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'vehiclesByTrip' );
+        expect( mbtapiClient.vehiclesByTrip ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the vehiclesbytrip endpoint', function() {
+        mbtapiClient.vehiclesByTrip( 'tripId' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/vehiclesbytrip?trip=tripId&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "trip" parameter to be specified', function() {
+        expect( mbtapiClient.vehiclesByTrip() ).to.be
+          .rejectedWith( 'missing required parameter: trip' );
+      });
+
+    });
+
+    describe( '.alerts', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'alerts' );
+        expect( mbtapiClient.alerts ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the alerts endpoint', function() {
+        mbtapiClient.alerts( 'tripId' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/alerts?api_key=apikey&format=json' );
+      });
+
+    });
+
+    describe( '.alertsByRoute', function() {
+
+      it( 'is a function', function() {
+        expect( mbtapiClient ).to.have.property( 'alertsByRoute' );
+        expect( mbtapiClient.alertsByRoute ).to.be.a( 'function' );
+      });
+
+      it( 'creates a request against the alertsByRoute endpoint', function() {
+        mbtapiClient.alertsByRoute( 'routeId' );
+        expect( restler.get ).to.have.been
+          .calledWith( 'apiroot/v2/alertsbyroute?route=routeId&api_key=apikey&format=json' );
+      });
+
+      it( 'requires the "route" parameter to be specified', function() {
+        expect( mbtapiClient.alertsByRoute() ).to.be
+          .rejectedWith( 'missing required parameter: route' );
+      });
+
+    });
+
+  });
+
+});

--- a/tests/specs/lib/make-query-handler.js
+++ b/tests/specs/lib/make-query-handler.js
@@ -1,0 +1,106 @@
+'use strict';
+
+/*jshint -W106 */// Disable underscore_case warnings in this file
+var chai = require( 'chai' );
+var expect = chai.expect;
+var sinon = require( 'sinon' );
+chai.use( require( 'sinon-chai' ) );
+chai.use( require( 'chai-as-promised' ) );
+var proxyquire = require( 'proxyquire' );
+
+describe( 'makeQueryHandler', function() {
+
+  var mockRestler;
+  var makeQueryHandler;
+  var data = {};
+  var config;
+
+  // Factory method to make it easier to fire events
+  function fireCbOn( targetEvent ) {
+    return function( evt, cb ) {
+      if ( evt === targetEvent ) {
+        cb( data );
+      }
+    };
+  }
+
+  beforeEach(function() {
+    mockRestler = {
+      // Default stub behavior: always succeed
+      get: sinon.stub().returns({
+        on: fireCbOn( 'success' )
+      })
+    };
+
+    config = {
+      apiKey: 'apikey',
+      apiRoot: 'apiroot/v2/'
+    };
+
+    makeQueryHandler = proxyquire( '../../../lib/make-query-handler', {
+      'restler': mockRestler
+    });
+  });
+
+  it( 'returns a function', function() {
+    var fn = makeQueryHandler( 'endpoint', [], config );
+
+    expect( fn ).to.be.a( 'function' );
+  });
+
+  it( 'returns a function that throws if insufficient arguments are provided', function() {
+    var fn = makeQueryHandler( 'endpoint', [ 'p1', 'p2' ], config );
+
+    return expect( fn( 'v1' ) ).to.be.rejectedWith( 'missing required parameter: p2' );
+  });
+
+  it( 'returns a function that throws if insufficient options are provided', function() {
+    var fn = makeQueryHandler( 'endpoint', [ 'p1', 'p2' ], config );
+
+    return expect( fn({
+      p2: 'v2'
+    }) ).to.be.rejectedWith( 'missing required parameter: p1' );
+  });
+
+  it( 'returns a function that throws if any required parameters are omitted', function() {
+    var fn = makeQueryHandler( 'endpoint', [ 'p1', 'p2', 'p3' ], config );
+
+    return expect( fn( 'v1', {
+      p3: 'v3'
+    }) ).to.be.rejectedWith( 'missing required parameter: p2' );
+  });
+
+  it( 'returns a function that maps provided values to required parameters', function() {
+    var fn = makeQueryHandler( 'endpoint', [ 'p1', 'p2', 'p3' ], config );
+    var prom = fn( 'v1', 'v2', 'v3' ).then(function( result ) {
+      return expect( mockRestler.get ).to.have.been
+        .calledWith( 'apiroot/v2/endpoint?p1=v1&p2=v2&p3=v3&api_key=apikey&format=json' );
+    });
+    return expect( prom ).to.be.fulfilled;
+  });
+
+  it( 'returns a function that can parse an object hash of query parameters', function() {
+    var fn = makeQueryHandler( 'endpoint', [ 'p1', 'p2', 'p3' ], config );
+    var prom = fn({
+      p1: 'v1',
+      p2: 'v2',
+      p3: 'v3'
+    }).then(function( result ) {
+      return expect( mockRestler.get ).to.have.been
+        .calledWith( 'apiroot/v2/endpoint?p1=v1&p2=v2&p3=v3&api_key=apikey&format=json' );
+    });
+    return expect( prom ).to.be.fulfilled;
+  });
+
+  it( 'returns a function that can parse explicit arguments and a params obj', function() {
+    var fn = makeQueryHandler( 'endpoint', [ 'p1', 'p2', 'p3' ], config );
+    var prom = fn( 'v1', 'v2', {
+      p3: 'v3'
+    }).then(function( result ) {
+      return expect( mockRestler.get ).to.have.been
+        .calledWith( 'apiroot/v2/endpoint?p1=v1&p2=v2&p3=v3&api_key=apikey&format=json' );
+    });
+    return expect( prom ).to.be.fulfilled;
+  });
+
+});

--- a/tests/test-api-query.js
+++ b/tests/test-api-query.js
@@ -6,6 +6,6 @@ var mbtapi = require( '../api' ).create({
 });
 
 // mbtapi.scheduleByRoute( '88' ).then(function)
-mbtapi.routes().then(function(results) {
-  console.log(results);
+mbtapi.routes().then(function( results ) {
+  console.log( results );
 });


### PR DESCRIPTION
The basic test suite was copied from MBTAwesome: mbtapi was the primary component of that application that was actually well-tested, so they have been ported wholesale and adapted to expect the config object to be passed as an argument to `.create`
